### PR TITLE
Implement Auth Provider

### DIFF
--- a/src/app/(contexts)/auth-provider.tsx
+++ b/src/app/(contexts)/auth-provider.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+import { AuthResponse } from '../(types)/auth'
+
+interface AuthContextProps {
+  user: AuthResponse['user'] | null
+  token: string | null
+  setAuth: (data: AuthResponse) => void
+  signOut: () => void
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined)
+
+export const AuthProvider = ({ children }: ChildrenProps) => {
+  const [user, setUser] = useState<AuthResponse['user'] | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem('auth_user')
+    const storedToken = localStorage.getItem('auth_token')
+
+    if (storedUser && storedToken) {
+      try {
+        setUser(JSON.parse(storedUser))
+        setToken(storedToken)
+      } catch {
+        localStorage.removeItem('auth_user')
+        localStorage.removeItem('auth_token')
+      }
+    }
+  }, [])
+
+  const setAuth = (data: AuthResponse) => {
+    setUser(data.user)
+    setToken(data.token)
+    localStorage.setItem('auth_user', JSON.stringify(data.user))
+    localStorage.setItem('auth_token', data.token)
+  }
+
+  const signOut = () => {
+    setUser(null)
+    setToken(null)
+    localStorage.removeItem('auth_user')
+    localStorage.removeItem('auth_token')
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, token, setAuth, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) throw new Error('useAuth must be used within AuthProvider')
+  return context
+}

--- a/src/app/(contexts)/index.tsx
+++ b/src/app/(contexts)/index.tsx
@@ -2,13 +2,16 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "./theme-provider";
+import { AuthProvider } from "./auth-provider";
 
 export const queryClient = new QueryClient();
 
 export const Contexts = ({ children }: ChildrenProps) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>{children}</ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider>{children}</ThemeProvider>
+      </AuthProvider>
     </QueryClientProvider>
   );
 };

--- a/src/app/(resources)/(forms)/sign-in.form.tsx
+++ b/src/app/(resources)/(forms)/sign-in.form.tsx
@@ -4,6 +4,8 @@ import { BaseForm } from "@/app/(components)/(bases)/(forms)/base-form";
 import { BaseInput } from "@/app/(components)/(bases)/(forms)/base-input";
 import { BaseButton } from "@/app/(components)/(bases)/base-button";
 import { SignInRequest } from "@/app/(http)/auth.http";
+import { useAuth } from "@/app/(contexts)/auth-provider";
+import { useRouter } from "next/navigation";
 import {
   SignInDefaultValues,
   SignInFormValues,
@@ -18,14 +20,19 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 export const SignInForm = () => {
+  const router = useRouter();
   const form = useForm({
     resolver: zodResolver(SignInSchema),
     defaultValues: SignInDefaultValues,
   });
 
+  const { setAuth } = useAuth();
+
   const { mutate, isPending } = SignInRequest({
-    onSuccess: () => {
+    onSuccess: (data) => {
+      setAuth(data);
       toast.success("Login efetuado com sucesso.");
+      router.push("/dashboard");
     },
     onError: ({ data }: any) => {
       toast.error(data.error);

--- a/src/app/(resources)/(forms)/sign-up.form.tsx
+++ b/src/app/(resources)/(forms)/sign-up.form.tsx
@@ -4,6 +4,8 @@ import { BaseForm } from "@/app/(components)/(bases)/(forms)/base-form";
 import { BaseInput } from "@/app/(components)/(bases)/(forms)/base-input";
 import { BaseButton } from "@/app/(components)/(bases)/base-button";
 import { SignUpRequest } from "@/app/(http)/auth.http";
+import { useAuth } from "@/app/(contexts)/auth-provider";
+import { useRouter } from "next/navigation";
 import {
   SignUpDefaultValues,
   SignUpFormValues,
@@ -18,14 +20,19 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
 export const SignUpForm = () => {
+  const router = useRouter();
   const form = useForm({
     resolver: zodResolver(SignUpSchema),
     defaultValues: SignUpDefaultValues,
   });
 
+  const { setAuth } = useAuth();
+
   const { mutate, isPending } = SignUpRequest({
-    onSuccess: () => {
+    onSuccess: (data) => {
+      setAuth(data);
       toast.success("Conta criada com sucesso. Você será redirecionado..");
+      router.push("/dashboard");
     },
     onError: ({ data }: any) => {
       toast.error(data.error);


### PR DESCRIPTION
## Summary
- implement `AuthProvider` for storing token and user data locally
- wrap existing context providers with new auth provider
- update sign-in and sign-up forms to store authentication on success
- redirect to `/dashboard` after successful sign-in or sign-up

## Testing
- `pnpm install` *(fails: Forbidden)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f667426c832ab1b8ede54aa0a216